### PR TITLE
Fixes 21002 errors from Apple

### DIFF
--- a/validateaction.php
+++ b/validateaction.php
@@ -62,7 +62,7 @@
     $isSandbox = (bool) $_GET['sandbox'];
  
     try {
-         if(strpos($receipt,'{'))
+         if(strpos($receipt,'{') !== false)
 {
 $receipt = base64_encode($receipt);
 }


### PR DESCRIPTION
When I was testing with your code, I would often receive 21002 errors from Apple.  A 21002 error means the receipt-data was malformed.  The issue was that when using a receipt that had { as the first character, strpos would return 0 and so the code would skip the base64_encode call.

I've changed the strpos check to check for not exactly false which will differentiate between position 0 and false and thus call base64_encode when needed.
