### PR TITLE
Move all print statements outside of the validateReceipt function to make it more re-usable.

### DIFF
--- a/validateaction.php
+++ b/validateaction.php
@@ -28,7 +28,7 @@ function validateReceipt($receipt, $endpoint) {
     }
  
     if (!isset($data->status) || $data->status != 0) {
-        throw new Exception('Invalid receipt. Status code: ' . $data->status);
+        throw new Exception('Invalid receipt. Status code: ' . (!empty($data->status) ? $data->status : 'N/A'));
     }
 
     return array(

--- a/validateaction.php
+++ b/validateaction.php
@@ -1,23 +1,13 @@
 <?php
-function validateReceipt($receipt, $isSandbox = true) {
-
-    if ($isSandbox) {
-        $endpoint = 'https://sandbox.itunes.apple.com/verifyReceipt';
-        print "Environment: Sandbox (use 'sandbox' URL argument to toggle)<br />";
-    }
-    else {
-        $endpoint = 'https://buy.itunes.apple.com/verifyReceipt';
-        print "Environment: Production (use 'sandbox' URL argument to toggle)<br />";
-    }
+function validateReceipt($receipt, $endpoint) {
 
     $postData = json_encode(
         array('receipt-data' => $receipt)
     );
-       
 
     $ch = curl_init($endpoint);
-    curl_setopt ($ch, CURLOPT_SSL_VERIFYHOST, 0);
-    curl_setopt ($ch, CURLOPT_SSL_VERIFYPEER, 0);
+    curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
+    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($ch, CURLOPT_POST, true);
     curl_setopt($ch, CURLOPT_POSTFIELDS, $postData);
@@ -38,8 +28,7 @@ function validateReceipt($receipt, $isSandbox = true) {
     }
  
     if (!isset($data->status) || $data->status != 0) {
-        print 'Status Code: '. $data->status . '<br/>';
-        throw new Exception('Invalid receipt');
+        throw new Exception('Invalid receipt. Status code: ' . $data->status);
     }
 
     return array(
@@ -56,11 +45,20 @@ function validateReceipt($receipt, $isSandbox = true) {
 $receipt   = $_GET['receipt'];
 $isSandbox = (bool) $_GET['sandbox'];
  
+if ($isSandbox) {
+    $endpoint = 'https://sandbox.itunes.apple.com/verifyReceipt';
+    print "Environment: Sandbox (use 'sandbox' URL argument to toggle)<br />";
+}
+else {
+    $endpoint = 'https://buy.itunes.apple.com/verifyReceipt';
+    print "Environment: Production (use 'sandbox' URL argument to toggle)<br />";
+}
+
 try {
     if(strpos($receipt,'{') !== false) {
         $receipt = base64_encode($receipt);
     }
-    $info = validateReceipt($receipt, $isSandbox);
+    $info = validateReceipt($receipt, $endpoint);
     echo 'Success';
 }
 catch (Exception $ex) {


### PR DESCRIPTION
In order to allow the validateReceipt function to be used in a wide variety of situations, I think it would be preferable if it didn't have hard coded print statements in it.

In this PR I've tried to move all the print statements out to the sample code at the bottom, which is primarily the choice of environment. That is now printed with the sample code at the bottom, and instead of passing in the $isSandbox variable, I now pass in the endpoint directly. We could still set the $endpoint inside validateReceipt if you want, but I like it better this way, as it makes it easy to add/change the urls in the future. For example, apple might add a "https://beta.itunes.apple.com/verifyReceipt" for testing new versions of their API, or I might run a local test service that pretends to be itunes.

Second, I now stick the error code into the exception instead of printing it. Now sure if that's optimal, but it looks nicer to me, as we can now easily use that exception to react in different ways to different status codes.
